### PR TITLE
Fix(logging): Resolve "Recovery completed" JSON parsing error

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ A research level Model Context Protocol (MCP) server implementation providing AI
 - 🔒 Fixed JSON communication to prevent parsing errors.
 - ⏱️ Performance tracking for operations.
 - 🔍 Enhanced logging with timestamps and debug level.
+- 🛡️ Fixed "Recovery completed" JSON parsing error.
+
+## 🆕 Fixed Recovery Procedure JSON Parsing Error
+
+This fork resolves the critical JSON parsing error: `MCP perplexity-server: Unexpected token 'R', "Recovery completed" is not valid JSON`
+
+The issue was caused by recovery messages being sent through stdout instead of stderr, which interfered with the JSON communication between MCP client and server. The fix:
+
+- All recovery procedure messages now use `logError()` to ensure they're sent to stderr
+- Modified the `log()` method to automatically route recovery-related info messages to stderr
+- Added special handling for recovery completion messages to guarantee they don't break JSON communication
 
 ## Enhanced Logging System
 


### PR DESCRIPTION
## Problem
This PR fixes the critical error: `MCP perplexity-server: Unexpected token 'R', "Recovery completed" is not valid JSON`

The issue was caused by recovery procedure messages being sent through stdout instead of stderr, which interfered with the JSON communication between MCP client and server.

## Solution

### Fixed in `recoveryProcedure` method:
- Changed all log messages in the recovery procedure to use `logError()` instead of `logInfo()`
- This ensures all recovery-related messages are sent to stderr and don't interfere with JSON communication
- Updated the recovery completion message to include timing information for better debugging

### Enhanced the `log()` method:
- Added special handling for recovery-related info messages to route them through stderr
- Any message containing "recovery" or "Recovery" is now automatically routed to stderr
- This provides an additional layer of protection for JSON communication

### Documentation:
- Added a dedicated section in the README explaining the fix
- Updated the features list to highlight the fix
- Added screenshots of the error for reference

## Testing
Tested with Claude Desktop to verify the recovery process no longer triggers JSON parsing errors.

## Related Issues
This resolves the JSON parsing error that was occurring during browser recovery procedures.